### PR TITLE
Rebuild with new analysis>2019C3.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 build:
   skip: True  # [py<36]
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
Should use https://github.com/nsls-ii-forge/analysis-feedstock/pull/7.