### PR TITLE
Simplify versions check

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,10 +37,9 @@ test:
   commands:
     - python -V
     - ipython -V
-    # Check versions (sys.exit(True) returns rc=1)
-    - python -c "import sys; from distutils.version import LooseVersion; import bluesky; sys.exit(not LooseVersion(bluesky.__version__) >= '1.6')"
-    - python -c "import sys; from distutils.version import LooseVersion; import databroker; sys.exit(not LooseVersion(databroker.__version__) >= '1.0')"
-    - python -c "import sys; from distutils.version import LooseVersion; import ophyd; sys.exit(not LooseVersion(ophyd.__version__) >= '1.4')"
+    - python -c "from distutils.version import LooseVersion; import bluesky; assert LooseVersion(bluesky.__version__) >= '1.6'"
+    - python -c "from distutils.version import LooseVersion; import databroker; assert LooseVersion(databroker.__version__) >= '1.0'"
+    - python -c "from distutils.version import LooseVersion; import ophyd; assert LooseVersion(ophyd.__version__) >= '1.4'"
 
 about:
   home: https://nsls-ii.github.io/deployment_docs.html


### PR DESCRIPTION
This PR is to make the test for the packages' versions simpler and consistent with the `analysis` metapackage (see https://github.com/nsls-ii-forge/analysis-feedstock/pull/10).

It's just the test update, we don't need to bump the build number.