### PR TITLE
Fix the 2020C1.0rc0 build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set year = "2020" %}
 {% set cycle = "1" %}
 {% set version = "0" %}
-{% set micro = "rc0" %}
+{% set micro = "rc1" %}
 
 package:
   name: {{ name }}
@@ -17,7 +17,7 @@ requirements:
     - python
   run:
     - python
-    - analysis >=2020C1.0rc0
+    - analysis >=2020C1.0rc1
     - caproto
     - nslsii >=0.0.12
     - pyepics >=3.4.1
@@ -37,7 +37,7 @@ test:
   commands:
     - python -V
     - ipython -V
-    - python -c "from distutils.version import LooseVersion; import bluesky; assert LooseVersion(bluesky.__version__) < '1.6'"
+    - python -c "from distutils.version import LooseVersion; import bluesky; assert LooseVersion(bluesky.__version__) >= '1.6'"
     - python -c "from distutils.version import LooseVersion; import databroker; assert LooseVersion(databroker.__version__) < '1.0'"
     - python -c "from distutils.version import LooseVersion; import ophyd; assert LooseVersion(ophyd.__version__) >= '1.4'"
 


### PR DESCRIPTION
The assertion of the bluesky version was wrong in https://dev.azure.com/nsls2forge/nsls2forge/_build/results?buildId=2073&view=logs&j=4f922444-fdfe-5dcf-b824-02f86439ef14&t=937c195f-508d-5135-dc9f-d4b5730df0f7.